### PR TITLE
Parallelize pseudo-experiments using multiple processes

### DIFF
--- a/roofit_stats.cc
+++ b/roofit_stats.cc
@@ -7,6 +7,7 @@
 #include <vector>
 #include <filesystem>
 
+#include "ROOT/TProcessExecutor.hxx"
 #include "RooRealVar.h"
 #include "RooGaussian.h"
 #include "RooLognormal.h"
@@ -66,8 +67,8 @@
         - mass: if runType = point, specify the mass of Suu for the analysis
         - nPseudoExps: the number of pseudo-experiments to be run
         - nToys: the number of toys generated for each pseudo-experiment
-        
-*/ 
+
+*/
 
 
 
@@ -96,10 +97,10 @@
     Data type holding:
         - the mass value
         - the theoretical signal yield and its uncertainty
-        - the theoretical background yield and its uncertainty 
+        - the theoretical background yield and its uncertainty
 */
 struct DataPoint {
-    double m_s; 
+    double m_s;
     double sig, sigma_sig;
     double bkg, sigma_bkg;
 };
@@ -115,7 +116,7 @@ int nToys = 1000;
 
 
 /*
-    Function taking as argument the path to the config file, parsing the 
+    Function taking as argument the path to the config file, parsing the
     config file and returning a map containing:
         - key: the defined property
         - value: the value of said property
@@ -139,7 +140,7 @@ std::map<std::string, std::string> load_Config(const char* inputFile) {
             if(start == std::string::npos) {s.clear(); return;}
             s = s.substr(start, end-start+1);
         };
-        
+
         // Check if line is empty
         trim(line);
         if(line.empty()) continue;
@@ -164,17 +165,16 @@ std::map<std::string, std::string> load_Config(const char* inputFile) {
     }
 
     return conf_Map;
-
 }
 
 
 
 /*
-    Function taking as argument the path of a .csv datafile and 
+    Function taking as argument the path of a .csv datafile and
     returns a vector of DataPoint type values.
 */
 std::vector<DataPoint> read_CSV(const char* inputFile) {
-    // Check if user has entered the path to the data file 
+    // Check if user has entered the path to the data file
     if(!inputFile) {
         throw std::runtime_error("Error: Please enter the name of the data file to be read.\n");
     }
@@ -185,14 +185,14 @@ std::vector<DataPoint> read_CSV(const char* inputFile) {
         throw std::runtime_error("Error: Please check the path of the input file.\n");
     }
 
-    std::cout << "Reading data from: " << inputFile << '\n';  
+    std::cout << "Reading data from: " << inputFile << '\n';
 
     std::vector<DataPoint> data;
     std::string line;
 
     // Skip header
     getline(csvFile, line);
-    
+
     // Parse csv file by line
     while(getline(csvFile, line)) {
         std::stringstream str(line);
@@ -209,7 +209,7 @@ std::vector<DataPoint> read_CSV(const char* inputFile) {
         if(getline(str, cell, ',')) point.bkg = stod(cell);
         // Background uncertainties
         if(getline(str, cell, ',')) point.sigma_bkg = stod(cell);
-            
+
         data.push_back(point);
     }
 
@@ -223,10 +223,10 @@ std::vector<DataPoint> read_CSV(const char* inputFile) {
     // Print the read data for debugging
     std::cout << "\n=== Summary by Mass Points ===\n";
     std::cout << "M_s [TeV]\t"
-         << "SIG\t\t\t" 
+         << "SIG\t\t\t"
          << "BKG\n";
     for (const DataPoint point : data)
-        std::cout << std::fixed << std::setprecision(2) << point.m_s << "\t\t" << std::scientific 
+        std::cout << std::fixed << std::setprecision(2) << point.m_s << "\t\t" << std::scientific
              << point.sig << " ± " << point.sigma_sig << "\t"
              << point.bkg << " ± " << point.sigma_bkg << "\n";
     std::cout << "\n" << std::fixed;
@@ -234,15 +234,22 @@ std::vector<DataPoint> read_CSV(const char* inputFile) {
     return data;
 }
 
+struct PseudoExperimentInput {
+    DataPoint point;
+    int index;
+};
 
+struct PseudoExperimentOutput {
+    TH1D hCLS, hCLSB, hCLB;
+    Double_t nTimesExcluded;
+    Double_t nTotalSB;
+};
 
-/*
-    Function that performs the statistical analysis and checks if the points are excluded or not
-    As an argument, pass the DataPoint associated to a given mass of Suu
-*/
-void analysisRun(DataPoint point, std::ofstream &prob_file) {
+PseudoExperimentOutput runPseudoExperiment(PseudoExperimentInput input) {
+    DataPoint point = input.point;
+    int index = input.index;
 
-    std::cout << Form("=== Running analysis for M_S = %.2f TeV ===\n", point.m_s);
+    RooRandom::randomGenerator()->SetSeed(index);
 
     /*
         Define a dummy "discriminator" variable, for example reconstructed mass.
@@ -256,7 +263,7 @@ void analysisRun(DataPoint point, std::ofstream &prob_file) {
 
     // define constraints on yields as lognormal distribution (to not allow negative yields).
     // Also plot the p.d.f. of the yields.
-    
+
     // ================ signal yield ===============================
     // "Observed" yield, i.e. the value you obtained from simulation
     RooRealVar S0_obs("S0_obs", "Signal yield from simulation", point.sig, 1E-6, 100.);
@@ -330,289 +337,335 @@ void analysisRun(DataPoint point, std::ofstream &prob_file) {
     globals.add(B0_obs);
     RooArgSet *sb_global_default_vals = globals.snapshot();
 
+    const auto startPseudoExp = std::chrono::high_resolution_clock::now();
+
+    // OPTION 1. Set the XX_true parameters to the default values in order to generate PSEUDOEXPERIMENTS the same way every-time.
+    sb_params.assign(*sb_params_default_vals);
+
+    // ############### GENERATING REAL DATA ####################
+
+    // 1. Global observables
+    // We regenerate those because if we were to "repeat" the experiment, you would redo the simulations as well, obtaining different
+    // S0_obs and B0_obs.
+    RooDataSet *ds_global = sb_full.generate(globals, 1);
+    globals.assign(*ds_global->get(0));
+    // std::cout << "================ globals ==============================" << std::endl;
+    // globals.Print("V");
+    // An alternative to the above is to the S0_obs and B0_obs as you obtained them from the initial simulation.
+    // https://indico.cern.ch/event/126652/contributions/1343592/attachments/80222/115004/Frequentist_Limit_Recommendation.pdf
+    // The doc above says such an approach does not have good asymptotic properties.
+    // globals.assign(*sb_global_default_vals);
+
+    // 2. Main data
+    mu.setVal(0.0); // we're generating bkg-only PSEUDOEXPERIMENT, so turn off the signal
+    mu.setConstant(true);
+    RooDataSet *ds = sb_full.generate({mass}, RooFit::Extended());
+    ds->setGlobalObservables(globals); // set global observables so that RooFit does not fit S0_obs and B0_obs
+    // std::cout << "================ ds ==============================" << std::endl;
+    // ds->Print("V");
+
+
+    // fit to s+b and record parameters and nll
+    // set and fix mu to 1.0, meaning full signal strength
+    sb_params.assign(*sb_params_default_vals);
+    mu.setVal(1.0);
+    mu.setConstant(true);
+    RooFitResult *result_mu = sb_full.fitTo(*ds, RooFit::Minimizer("Minuit2", "Migrad"), RooFit::PrintLevel(-1),
+                                            RooFit::PrintEvalErrors(-1), RooFit::Warnings(false),
+                                            RooFit::Verbose(false), RooFit::Save(), RooFit::GlobalObservables(globals));
+    // std::cout << "================ mu=1 fit ==============================" << std::endl;
+    // result_mu->Print("V");
+    Double_t nll_mu = result_mu->minNll();
+    RooArgSet *params_fit_sb = sb_params.snapshot();
+    // params_fit_sb->Print("V");
+
+
+    // fit to b-only and record parameters and nll
+    // allow mu to float as described in the documents.
+    mu.setVal(1E-5);
+    mu.setConstant(false);
+    RooFitResult *result_mu_hat = sb_full.fitTo(*ds, RooFit::Minimizer("Minuit2", "Migrad"), RooFit::PrintLevel(-1),
+                                                RooFit::PrintEvalErrors(-1), RooFit::Warnings(false),
+                                                RooFit::Verbose(false), RooFit::Save(), RooFit::GlobalObservables(globals));
+    // std::cout << "================ mu_hat fit ==============================" << std::endl;
+    // result_mu_hat->Print("V");
+    Double_t nll_mu_hat = result_mu_hat->minNll();
+    // construct the test statistic of the "observed" data
+    // Q = -2 ln (L(mu=1)/L(mu_hat)) = -2 * (ln(L(mu=1)) - ln(L(mu_hat))) = 2*(nll(mu=1) - nll(mu_hat))
+    Double_t q_obs = 2. * (nll_mu - nll_mu_hat);
+
+
+    // fit under pure background to find nuissance parameters
+    mu.setVal(0.0);
+    mu.setConstant(true);
+    RooFitResult *result_b = sb_full.fitTo(*ds, RooFit::Minimizer("Minuit2", "Migrad"), RooFit::PrintLevel(-1),
+                                            RooFit::PrintEvalErrors(-1), RooFit::Warnings(false),
+                                            RooFit::Verbose(false), RooFit::Save(), RooFit::GlobalObservables(globals));
+    // std::cout << "================ bkg fit ==============================" << std::endl;
+    // result_b->Print("V");
+    RooArgSet *params_fit_b = sb_params.snapshot();
+    // params_fit_b->Print("V");
+
+    const auto startFull = std::chrono::high_resolution_clock::now();
+
+    // Build distribution of q under b-only and count how many times the TOY has a higher q than the PSEUDOEXPERIMENT.
+    // This number is 1-CLB (as defined in https://cds.cern.ch/record/1379837/files/NOTE2011_005.pdf)
+    Double_t n_higher_bkg = 0.0;
+    // histogram for the distribution of q under B-only
+    // This will show that when using the "unconstrained" ensemble, the q_mu dsitributions do not depend on the pseudoexperiment
+    // So one can derive them only once. In this code we do not use this property, but it's very nice to have in mind.
+    TH1D *hqB_check = new TH1D(Form("hqB_check_%d", index), Form("q distr under bkg only, pseudoexp %d", index), 50, 0., 20.);
+    for (Int_t i_toy = 0; i_toy < nToys; ++i_toy)
+    {
+        const auto startToy = std::chrono::high_resolution_clock::now();
+        // OPTION 1. Set the bkg yield to the one obtained from the PSEUDOEXPERIMENT fit.
+        // sb_params.assign(*params_fit_b);
+        sb_params.assign(*params_fit_b);
+
+
+        // generate the "XX_obs" variables
+        RooDataSet *ds_global_toy = sb_full.generate(globals, 1);
+        globals.assign(*ds_global_toy->get(0));
+
+        mu.setVal(0.0);
+        RooDataSet *ds_toy = sb_full.generate({mass}, RooFit::Extended());
+        ds_toy->setGlobalObservables(globals);
+        mu.setVal(1.0);
+        mu.setConstant(true);
+        RooFitResult *result_mu_toy = sb_full.fitTo(*ds_toy, RooFit::Minimizer("Minuit2", "Migrad"), RooFit::PrintLevel(-1),
+                                                    RooFit::PrintEvalErrors(-1), RooFit::Warnings(false),
+                                                    RooFit::Verbose(false), RooFit::Save(), RooFit::GlobalObservables(globals));
+        Double_t nll_mu_toy = result_mu_toy->minNll();
+
+        // mu.setVal(1E-5);
+        mu.setConstant(false);
+        RooFitResult *result_mu_hat_toy = sb_full.fitTo(*ds_toy, RooFit::Minimizer("Minuit2", "Migrad"), RooFit::PrintLevel(-1),
+                                                        RooFit::PrintEvalErrors(-1), RooFit::Warnings(false),
+                                                        RooFit::Verbose(false), RooFit::Save(), RooFit::GlobalObservables(globals));
+        Double_t nll_mu_hat_toy = result_mu_hat_toy->minNll();
+
+        Double_t q_toy = 2. * (nll_mu_toy - nll_mu_hat_toy);
+        delete result_mu_toy;
+        result_mu_toy = nullptr;
+        delete result_mu_hat_toy;
+        result_mu_hat_toy=nullptr;
+        delete ds_toy;
+        ds_toy = nullptr;
+        delete ds_global_toy;
+        ds_global_toy = nullptr;
+
+
+        if (q_toy >= q_obs)
+        {
+            n_higher_bkg += 1.0;
+        }
+
+        hqB_check->Fill(q_toy);
+
+        // remove the line below if you want to do debug printing.
+        const auto stopToy = std::chrono::high_resolution_clock::now();
+        auto durationToy = std::chrono::duration_cast<std::chrono::microseconds>(stopToy - startToy);
+        auto durationPE = std::chrono::duration_cast<std::chrono::milliseconds>(stopToy - startPseudoExp);
+        auto durationNow = std::chrono::duration_cast<std::chrono::milliseconds>(stopToy - startFull);
+
+        Double_t durationToyNice = durationToy.count() / 1000.; // ms
+        Double_t durationPENice = durationNow.count() / 1000.;  // s
+        Double_t durationNowNice = durationNow.count() / 1000.; // s
+        if ((i_toy+1) % (nToys / 2) == 0)
+        {
+            std::cout << "\r Ran pseudo-experiment " << index+1 << "/" << nPseudoExps
+                        << ": bkg toy " << i_toy+1 << "/" << nToys
+                        << " Duration: " << durationNowNice << "[s]" << std::flush;
+        }
+        // hTimeBkgToy->Fill(durationToyNice);
+    }
+
+    // TCanvas *cqB = new TCanvas(Form("cqB_%i", i),Form("cqB_%i", i), 800, 600);
+    // cqB->cd();
+    // hqB_check->Draw();
+    // TLine *line_obs = new TLine(q_obs, 0., q_obs, hqB_check->GetMaximum());
+    // line_obs->SetLineColor(kRed);
+    // line_obs->SetLineWidth(2);
+    // line_obs->Draw("SAME");
+    // output_file->cd();
+    // cqB->Write();
+
+    // delete cqB;
+    // cqB=nullptr;
+    // delete line_obs;
+    // line_obs=nullptr;
+    // delete hqB_check;
+    // hqB_check = nullptr;
+
+    // Build distribution of q under S+B and count how many times the TOY has a higher q than the PSEUDOEXPERIMENT.
+    // This number is CLSB (as defined in https://cds.cern.ch/record/1379837/files/NOTE2011_005.pdf)
+    Double_t n_higher_sb = 0.0;
+    TH1D *hqSB_check = new TH1D(Form("hqSB_check_%d", index), Form("q distr under sb, pseudoexp %d", index), 50, 0., 20.);
+    for (Int_t i_toy = 0; i_toy < nToys; ++i_toy)
+    {
+        const auto startToy = std::chrono::high_resolution_clock::now();
+        // OPTION 1. set the signal and bkg yield to the one obtained from the PSEUDOEXPERIMENT fit.
+        sb_params.assign(*sb_params_default_vals);
+
+        // sb_full.generate(b_params);
+        // OPTION 2. Sample the signal and bkg yield before generating the PSEUDOEXPERIMENTS.
+        // NOT a frequentist construction, but we should not fear this.
+        RooDataSet *ds_global_toy = sb_full.generate(globals, 1);
+        globals.assign(*ds_global_toy->get(0));
+        mu.setVal(1.0);
+        RooDataSet *ds_toy = sb_full.generate({mass}, RooFit::Extended());
+        ds_toy->setGlobalObservables(globals);
+        mu.setVal(1.0);
+        mu.setConstant(true);
+        RooFitResult *result_mu_toy = sb_full.fitTo(*ds_toy, RooFit::Minimizer("Minuit2", "Migrad"), RooFit::PrintLevel(-1),
+                                                    RooFit::PrintEvalErrors(-1), RooFit::Warnings(false),
+                                                    RooFit::Verbose(false), RooFit::Save(), RooFit::GlobalObservables(globals));
+        Double_t nll_mu_toy = result_mu_toy->minNll();
+        mu.setVal(1E-5);
+        mu.setConstant(false);
+        RooFitResult *result_mu_hat_toy = sb_full.fitTo(*ds_toy, RooFit::Minimizer("Minuit2", "Migrad"), RooFit::PrintLevel(-1),
+                                                        RooFit::PrintEvalErrors(-1), RooFit::Warnings(false),
+                                                        RooFit::Verbose(false), RooFit::Save(), RooFit::GlobalObservables(globals));
+        Double_t nll_mu_hat_toy = result_mu_hat_toy->minNll();
+
+        Double_t q_toy = 2. * (nll_mu_toy - nll_mu_hat_toy);
+
+        delete result_mu_toy;
+        result_mu_toy = nullptr;
+        delete result_mu_hat_toy;
+        result_mu_hat_toy=nullptr;
+        delete ds_toy;
+        ds_toy = nullptr;
+        delete ds_global_toy;
+        ds_global_toy = nullptr;
+
+
+        if (q_toy >= q_obs)
+        {
+            n_higher_sb += 1.0;
+        }
+        hqSB_check->Fill(q_toy);
+
+        // remove the line below if you want to do debug printing.
+        const auto stopToy = std::chrono::high_resolution_clock::now();
+        auto durationToy = std::chrono::duration_cast<std::chrono::microseconds>(stopToy - startToy);
+        auto durationPE = std::chrono::duration_cast<std::chrono::milliseconds>(stopToy - startPseudoExp);
+        auto durationNow = std::chrono::duration_cast<std::chrono::milliseconds>(stopToy - startFull);
+
+        Double_t durationToyNice = durationToy.count() / 1000.; // ms
+        Double_t durationPENice = durationNow.count() / 1000.;  // s
+        Double_t durationNowNice = durationNow.count() / 1000.; // s
+        if ((i_toy+1) % (nToys / 2) == 0)
+        {
+            std::cout << "\r Ran pseudo-experiment " << index+1 << "/" << nPseudoExps
+                        << ": s+b toy " << i_toy+1 << "/" << nToys
+                        << " Duration: " << durationNowNice << "[s]" << std::flush;
+        }
+        // hTimeSBToy->Fill(durationToyNice);
+    }
+
+    // TCanvas *cqSB = new TCanvas(Form("cqSB_%i", i),Form("cqSB_%i", i), 800, 600);
+    // cqSB->cd();
+    // hqSB_check->Draw();
+    // line_obs = new TLine(q_obs, 0., q_obs, hqSB_check->GetMaximum());
+    // line_obs->SetLineColor(kRed);
+    // line_obs->SetLineWidth(2);
+    // line_obs->Draw("SAME");
+    // output_file->cd();
+    // cqSB->Write();
+
+    // delete cqSB;
+    // cqSB=nullptr;
+    // delete line_obs;
+    // line_obs=nullptr;
+    // delete hqSB_check;
+    // hqSB_check = nullptr;
+
+    // Computation of CLs. Exactly as described in the notes
+    Double_t clSB = (1.0 * n_higher_sb) / (1.0 * nToys);
+    Double_t clB = (1.0 * n_higher_bkg) / (1.0 * nToys);
+    Double_t CLS = clB > 0. ? clSB / clB : 0.0;
+
+    // dsitributions of CLS, CLSB and CLB
+    TH1D hCLS = TH1D("hCLS", "CLS", 100, 0., 1.);
+    TH1D hCLSB = TH1D("hCLSB", "CLSB", 100, 0., 1.);
+    TH1D hCLB = TH1D("hCLB", "1-CLB", 100, 0., 1.);
+    hCLS.Fill(CLS);
+    hCLSB.Fill(clSB);
+    hCLB.Fill(clB);
+
+    // Assume 95% confindence level
+    bool excluded = false;
+    if (CLS < 0.05)
+    {
+        excluded = true;
+    }
+
+    const auto stopPE = std::chrono::high_resolution_clock::now();
+    auto durationPE = std::chrono::duration_cast<std::chrono::milliseconds>(stopPE - startPseudoExp);
+    // Double_t durationPENice = durationPE.count() / 1000.; // s
+    // hTimePseudoExp->Fill(durationPENice);
+
+    delete cSigConstraint;
+    cSigConstraint = nullptr;
+    delete cBkgConstraint;
+    cBkgConstraint = nullptr;
+
+    return {hCLS, hCLSB, hCLB, excluded ? 1.0 : 0.0, n_higher_sb};
+}
+
+
+/*
+    Function that performs the statistical analysis and checks if the points are excluded or not
+    As an argument, pass the DataPoint associated to a given mass of Suu
+*/
+void analysisRun(DataPoint point, std::ofstream &prob_file) {
+    std::cout << Form("=== Running analysis for M_S = %.2f TeV ===\n", point.m_s);
+
     if(std::filesystem::create_directories(Form("results/mChi2/roofit_results/out_D%d", discriminator)))
     ;
-    TFile *output_file = TFile::Open(Form("results/mChi2/roofit_results/out_D%d/output_S%d.root", discriminator, int(point.m_s*100)), "RECREATE");    
-    // dsitributions of CLS, CLSB and CLB
-    TH1D *hCLS = new TH1D("hCLS", "CLS", 100, 0., 1.);
-    TH1D *hCLSB = new TH1D("hCLSB", "CLSB", 100, 0., 1.);
-    TH1D *hCLB = new TH1D("hCLB", "1-CLB", 100, 0., 1.);
+    TFile *output_file = TFile::Open(Form("results/mChi2/roofit_results/out_D%d/output_S%d.root", discriminator, int(point.m_s*100)), "RECREATE");
+
 
     // Number of PSEUDOEXPERIMENTS. Recommend 100 at least, maybe 1000
     // Number of TOYS per PSEUDOEXPERIMENTS. Recommend 1000 at least, maybe 10000
-    TH1D *hTimeBkgToy = new TH1D("hTimeBkgToy", "Bkg toys; Toy time [ms]", 100, 0., 20.);
-    TH1D *hTimeSBToy = new TH1D("hTimeSBToy", "SB toys; Toy time [ms]", 100, 0., 20.);
-    TH1D *hTimePseudoExp = new TH1D("hTimePseudoExp", "Pseudo-experiments; PE time [s]", 100, 0., 20. * nToys / 1000.);
-
-    // Counter to check how often we exclude the parameter point (in which the signal yield is what it is above).
-    Double_t nTimesExcluded = 0.0;
-    Double_t nTotalSB = 0.;
-    const auto startFull = std::chrono::high_resolution_clock::now();
-    for (Int_t i = 0; i < nPseudoExps; ++i) {
-        const auto startPseudoExp = std::chrono::high_resolution_clock::now();
-        // OPTION 1. Set the XX_true parameters to the default values in order to generate PSEUDOEXPERIMENTS the same way every-time.
-        sb_params.assign(*sb_params_default_vals);
-
-        // ############### GENERATING REAL DATA ####################
-
-        // 1. Global observables
-        // We regenerate those because if we were to "repeat" the experiment, you would redo the simulations as well, obtaining different
-        // S0_obs and B0_obs.
-        RooDataSet *ds_global = sb_full.generate(globals, 1);
-        globals.assign(*ds_global->get(0));
-        // std::cout << "================ globals ==============================" << std::endl;
-        // globals.Print("V");
-        // An alternative to the above is to the S0_obs and B0_obs as you obtained them from the initial simulation.
-        // https://indico.cern.ch/event/126652/contributions/1343592/attachments/80222/115004/Frequentist_Limit_Recommendation.pdf
-        // The doc above says such an approach does not have good asymptotic properties.
-        // globals.assign(*sb_global_default_vals);
-
-        // 2. Main data
-        mu.setVal(0.0); // we're generating bkg-only PSEUDOEXPERIMENT, so turn off the signal
-        mu.setConstant(true);
-        RooDataSet *ds = sb_full.generate({mass}, RooFit::Extended());
-        ds->setGlobalObservables(globals); // set global observables so that RooFit does not fit S0_obs and B0_obs
-        // std::cout << "================ ds ==============================" << std::endl;
-        // ds->Print("V");
+    // TH1D *hTimeBkgToy = new TH1D("hTimeBkgToy", "Bkg toys; Toy time [ms]", 100, 0., 20.);
+    // TH1D *hTimeSBToy = new TH1D("hTimeSBToy", "SB toys; Toy time [ms]", 100, 0., 20.);
+    // TH1D *hTimePseudoExp = new TH1D("hTimePseudoExp", "Pseudo-experiments; PE time [s]", 100, 0., 20. * nToys / 1000.);
 
 
-        // fit to s+b and record parameters and nll
-        // set and fix mu to 1.0, meaning full signal strength
-        sb_params.assign(*sb_params_default_vals);
-        mu.setVal(1.0);
-        mu.setConstant(true);
-        RooFitResult *result_mu = sb_full.fitTo(*ds, RooFit::Minimizer("Minuit2", "Migrad"), RooFit::PrintLevel(-1),
-                                                RooFit::PrintEvalErrors(-1), RooFit::Warnings(false),
-                                                RooFit::Verbose(false), RooFit::Save(), RooFit::GlobalObservables(globals));
-        // std::cout << "================ mu=1 fit ==============================" << std::endl;
-        // result_mu->Print("V");
-        Double_t nll_mu = result_mu->minNll();
-        RooArgSet *params_fit_sb = sb_params.snapshot();
-        // params_fit_sb->Print("V");
+    // Create a pool of processes (size = number of CPU cores by default)
+    ROOT::TProcessExecutor pool;
 
-
-        // fit to b-only and record parameters and nll
-        // allow mu to float as described in the documents.
-        mu.setVal(1E-5);
-        mu.setConstant(false);
-        RooFitResult *result_mu_hat = sb_full.fitTo(*ds, RooFit::Minimizer("Minuit2", "Migrad"), RooFit::PrintLevel(-1),
-                                                    RooFit::PrintEvalErrors(-1), RooFit::Warnings(false),
-                                                    RooFit::Verbose(false), RooFit::Save(), RooFit::GlobalObservables(globals));
-        // std::cout << "================ mu_hat fit ==============================" << std::endl;
-        // result_mu_hat->Print("V");
-        Double_t nll_mu_hat = result_mu_hat->minNll();
-        // construct the test statistic of the "observed" data
-        // Q = -2 ln (L(mu=1)/L(mu_hat)) = -2 * (ln(L(mu=1)) - ln(L(mu_hat))) = 2*(nll(mu=1) - nll(mu_hat))
-        Double_t q_obs = 2. * (nll_mu - nll_mu_hat);
-        
-
-        // fit under pure background to find nuissance parameters
-        mu.setVal(0.0);
-        mu.setConstant(true);
-        RooFitResult *result_b = sb_full.fitTo(*ds, RooFit::Minimizer("Minuit2", "Migrad"), RooFit::PrintLevel(-1),
-                                               RooFit::PrintEvalErrors(-1), RooFit::Warnings(false),
-                                               RooFit::Verbose(false), RooFit::Save(), RooFit::GlobalObservables(globals));
-        // std::cout << "================ bkg fit ==============================" << std::endl;
-        // result_b->Print("V");
-        RooArgSet *params_fit_b = sb_params.snapshot();
-        // params_fit_b->Print("V");
-
-
-        // Build distribution of q under b-only and count how many times the TOY has a higher q than the PSEUDOEXPERIMENT.
-        // This number is 1-CLB (as defined in https://cds.cern.ch/record/1379837/files/NOTE2011_005.pdf)
-        Double_t n_higher_bkg = 0.0;
-        // histogram for the distribution of q under B-only
-        // This will show that when using the "unconstrained" ensemble, the q_mu dsitributions do not depend on the pseudoexperiment
-        // So one can derive them only once. In this code we do not use this property, but it's very nice to have in mind.
-        TH1D *hqB_check = new TH1D(Form("hqB_check_%d", i), Form("q distr under bkg only, pseudoexp %d", i), 50, 0., 20.);
-        for (Int_t i_toy = 0; i_toy < nToys; ++i_toy)
-        {
-            const auto startToy = std::chrono::high_resolution_clock::now();
-            // OPTION 1. Set the bkg yield to the one obtained from the PSEUDOEXPERIMENT fit.
-            // sb_params.assign(*params_fit_b);
-            sb_params.assign(*params_fit_b);
-            
-
-            // generate the "XX_obs" variables
-            RooDataSet *ds_global_toy = sb_full.generate(globals, 1);
-            globals.assign(*ds_global_toy->get(0));
-            
-            mu.setVal(0.0);
-            RooDataSet *ds_toy = sb_full.generate({mass}, RooFit::Extended());
-            ds_toy->setGlobalObservables(globals);
-            mu.setVal(1.0);
-            mu.setConstant(true);
-            RooFitResult *result_mu_toy = sb_full.fitTo(*ds_toy, RooFit::Minimizer("Minuit2", "Migrad"), RooFit::PrintLevel(-1),
-                                                        RooFit::PrintEvalErrors(-1), RooFit::Warnings(false),
-                                                        RooFit::Verbose(false), RooFit::Save(), RooFit::GlobalObservables(globals));
-            Double_t nll_mu_toy = result_mu_toy->minNll();
-            
-            // mu.setVal(1E-5);
-            mu.setConstant(false);
-            RooFitResult *result_mu_hat_toy = sb_full.fitTo(*ds_toy, RooFit::Minimizer("Minuit2", "Migrad"), RooFit::PrintLevel(-1),
-                                                            RooFit::PrintEvalErrors(-1), RooFit::Warnings(false),
-                                                            RooFit::Verbose(false), RooFit::Save(), RooFit::GlobalObservables(globals));
-            Double_t nll_mu_hat_toy = result_mu_hat_toy->minNll();
-
-            Double_t q_toy = 2. * (nll_mu_toy - nll_mu_hat_toy);
-            delete result_mu_toy;
-            result_mu_toy = nullptr;
-            delete result_mu_hat_toy;
-            result_mu_hat_toy=nullptr;
-            delete ds_toy;
-            ds_toy = nullptr;
-            delete ds_global_toy;
-            ds_global_toy = nullptr;
-            
-            
-            if (q_toy >= q_obs)
-            {
-                n_higher_bkg += 1.0;
-            }
-
-            hqB_check->Fill(q_toy);
-
-            // remove the line below if you want to do debug printing.
-            const auto stopToy = std::chrono::high_resolution_clock::now();
-            auto durationToy = std::chrono::duration_cast<std::chrono::microseconds>(stopToy - startToy);
-            auto durationPE = std::chrono::duration_cast<std::chrono::milliseconds>(stopToy - startPseudoExp);
-            auto durationNow = std::chrono::duration_cast<std::chrono::milliseconds>(stopToy - startFull);
-
-            Double_t durationToyNice = durationToy.count() / 1000.; // ms
-            Double_t durationPENice = durationNow.count() / 1000.;  // s
-            Double_t durationNowNice = durationNow.count() / 1000.; // s
-            if ((i_toy+1) % (nToys / 2) == 0)
-            {
-                std::cout << "\r Ran pseudo-experiment " << i+1 << "/" << nPseudoExps
-                          << ": bkg toy " << i_toy+1 << "/" << nToys
-                          << " Duration: " << durationNowNice << "[s]" << std::flush;
-            }
-            hTimeBkgToy->Fill(durationToyNice);
-        }
-
-        TCanvas *cqB = new TCanvas(Form("cqB_%i", i),Form("cqB_%i", i), 800, 600);
-        cqB->cd();
-        hqB_check->Draw();
-        TLine *line_obs = new TLine(q_obs, 0., q_obs, hqB_check->GetMaximum());
-        line_obs->SetLineColor(kRed);
-        line_obs->SetLineWidth(2);
-        line_obs->Draw("SAME");
-        output_file->cd();
-        cqB->Write();
-
-        delete cqB;
-        cqB=nullptr;
-        delete line_obs;
-        line_obs=nullptr;
-        delete hqB_check;
-        hqB_check = nullptr;
-
-        // Build distribution of q under S+B and count how many times the TOY has a higher q than the PSEUDOEXPERIMENT.
-        // This number is CLSB (as defined in https://cds.cern.ch/record/1379837/files/NOTE2011_005.pdf)
-        Double_t n_higher_sb = 0.0;
-        TH1D *hqSB_check = new TH1D(Form("hqSB_check_%d", i), Form("q distr under sb, pseudoexp %d", i), 50, 0., 20.);
-        for (Int_t i_toy = 0; i_toy < nToys; ++i_toy)
-        {
-            const auto startToy = std::chrono::high_resolution_clock::now();
-            // OPTION 1. set the signal and bkg yield to the one obtained from the PSEUDOEXPERIMENT fit.
-            sb_params.assign(*sb_params_default_vals);
-
-            // sb_full.generate(b_params);
-            // OPTION 2. Sample the signal and bkg yield before generating the PSEUDOEXPERIMENTS.
-            // NOT a frequentist construction, but we should not fear this.
-            RooDataSet *ds_global_toy = sb_full.generate(globals, 1);
-            globals.assign(*ds_global_toy->get(0));
-            mu.setVal(1.0);
-            RooDataSet *ds_toy = sb_full.generate({mass}, RooFit::Extended());
-            ds_toy->setGlobalObservables(globals);
-            mu.setVal(1.0);
-            mu.setConstant(true);
-            RooFitResult *result_mu_toy = sb_full.fitTo(*ds_toy, RooFit::Minimizer("Minuit2", "Migrad"), RooFit::PrintLevel(-1),
-                                                        RooFit::PrintEvalErrors(-1), RooFit::Warnings(false),
-                                                        RooFit::Verbose(false), RooFit::Save(), RooFit::GlobalObservables(globals));
-            Double_t nll_mu_toy = result_mu_toy->minNll();
-            mu.setVal(1E-5);
-            mu.setConstant(false);
-            RooFitResult *result_mu_hat_toy = sb_full.fitTo(*ds_toy, RooFit::Minimizer("Minuit2", "Migrad"), RooFit::PrintLevel(-1),
-                                                            RooFit::PrintEvalErrors(-1), RooFit::Warnings(false),
-                                                            RooFit::Verbose(false), RooFit::Save(), RooFit::GlobalObservables(globals));
-            Double_t nll_mu_hat_toy = result_mu_hat_toy->minNll();
-
-            Double_t q_toy = 2. * (nll_mu_toy - nll_mu_hat_toy);
-
-            delete result_mu_toy;
-            result_mu_toy = nullptr;
-            delete result_mu_hat_toy;
-            result_mu_hat_toy=nullptr;
-            delete ds_toy;
-            ds_toy = nullptr;
-            delete ds_global_toy;
-            ds_global_toy = nullptr;
-            
-
-            if (q_toy >= q_obs)
-            {
-                n_higher_sb += 1.0;
-            }
-            hqSB_check->Fill(q_toy);
-
-            // remove the line below if you want to do debug printing.
-            const auto stopToy = std::chrono::high_resolution_clock::now();
-            auto durationToy = std::chrono::duration_cast<std::chrono::microseconds>(stopToy - startToy);
-            auto durationPE = std::chrono::duration_cast<std::chrono::milliseconds>(stopToy - startPseudoExp);
-            auto durationNow = std::chrono::duration_cast<std::chrono::milliseconds>(stopToy - startFull);
-
-            Double_t durationToyNice = durationToy.count() / 1000.; // ms
-            Double_t durationPENice = durationNow.count() / 1000.;  // s
-            Double_t durationNowNice = durationNow.count() / 1000.; // s
-            if ((i_toy+1) % (nToys / 2) == 0)
-            {
-                std::cout << "\r Ran pseudo-experiment " << i+1 << "/" << nPseudoExps
-                          << ": s+b toy " << i_toy+1 << "/" << nToys
-                          << " Duration: " << durationNowNice << "[s]" << std::flush;
-            }
-            hTimeSBToy->Fill(durationToyNice);
-        }
-
-        TCanvas *cqSB = new TCanvas(Form("cqSB_%i", i),Form("cqSB_%i", i), 800, 600);
-        cqSB->cd();
-        hqSB_check->Draw();
-        line_obs = new TLine(q_obs, 0., q_obs, hqSB_check->GetMaximum());
-        line_obs->SetLineColor(kRed);
-        line_obs->SetLineWidth(2);
-        line_obs->Draw("SAME");
-        output_file->cd();
-        cqSB->Write();
-
-        delete cqSB;
-        cqSB=nullptr;
-        delete line_obs;
-        line_obs=nullptr;
-        delete hqSB_check;
-        hqSB_check = nullptr;
-
-        // Computation of CLs. Exactly as described in the notes
-        Double_t clSB = (1.0 * n_higher_sb) / (1.0 * nToys);
-        Double_t clB = (1.0 * n_higher_bkg) / (1.0 * nToys);
-        Double_t CLS = clB > 0. ? clSB / clB : 0.0;
-        hCLS->Fill(CLS);
-        hCLSB->Fill(clSB);
-        hCLB->Fill(clB);
-        // Assume 95% confindence level
-        if (CLS < 0.05)
-        {
-            nTimesExcluded += 1.0;
-        }
-        nTotalSB += n_higher_sb;
-        
-        const auto stopPE = std::chrono::high_resolution_clock::now();
-        auto durationPE = std::chrono::duration_cast<std::chrono::milliseconds>(stopPE - startPseudoExp);
-        Double_t durationPENice = durationPE.count() / 1000.; // s
-        hTimePseudoExp->Fill(durationPENice);
+    // Create a vector to store the inputs for each pseudo-experiment
+    std::vector<PseudoExperimentInput> inputs(nPseudoExps);
+    for (int i = 0; i < nPseudoExps; ++i) {
+        inputs[i] = {point, i+1};
     }
 
+    // Run in parallel: each process executes runToy(seed)
+    PseudoExperimentOutput outputs = pool.MapReduce(runPseudoExperiment, inputs, [] (const std::vector<PseudoExperimentOutput>& results) {
+        PseudoExperimentOutput combined;
+        combined.hCLS = TH1D("hCLS", "CLS", 100, 0., 1.);
+        combined.hCLSB = TH1D("hCLSB", "CLSB", 100, 0., 1.);
+        combined.hCLB = TH1D("hCLB", "1-CLB", 100, 0., 1.);
+        combined.nTimesExcluded = 0.0;
+        combined.nTotalSB = 0.0;
+        for (const auto& res : results) {
+            combined.hCLS.Add(&res.hCLS);
+            combined.hCLSB.Add(&res.hCLSB);
+            combined.hCLB.Add(&res.hCLB);
+            combined.nTimesExcluded += res.nTimesExcluded;
+            combined.nTotalSB += res.nTotalSB;
+        }
+        return combined;
+    });
+
+    // Counter to check how often we exclude the parameter point (in which the signal yield is what it is above).
+
+
     std::cout << std::endl;
-    Double_t ratioExcluded = (1.0*nTimesExcluded)/(1.0*nPseudoExps);
+    Double_t ratioExcluded = (1.0*outputs.nTimesExcluded)/(1.0*nPseudoExps);
     std::cout << "Point excluded " << 100*ratioExcluded << "\% of the time.";
     if (ratioExcluded < 0.0228){
         std::cout << " It is outside the +-2sigma band; below the median";
@@ -633,42 +686,35 @@ void analysisRun(DataPoint point, std::ofstream &prob_file) {
         std::cout << "It is outside the +-2sigma band, above the median";
     }
     std::cout << std::endl;
-    
-    prob_file << std::fixed << std::setprecision(2) << point.m_s << "," << std::setprecision(5) << std::scientific << nTotalSB/(nPseudoExps*nToys) << '\n';
+
+    prob_file << std::fixed << std::setprecision(2) << point.m_s << "," << std::setprecision(5) << std::scientific << outputs.nTotalSB/(nPseudoExps*nToys) << '\n';
     std::cout << std::fixed << std::setprecision(2);
 
     TCanvas *c_cls = new TCanvas("c_cls", "c_cls");
     c_cls->Divide(3, 1);
     c_cls->cd(1);
-    hCLS->DrawCopy();
+    outputs.hCLS.DrawCopy();
     c_cls->cd(2);
-    hCLSB->DrawCopy();
+    outputs.hCLSB.DrawCopy();
     c_cls->cd(3);
-    hCLB->DrawCopy();
+    outputs.hCLB.DrawCopy();
 
-    TCanvas *c_time = new TCanvas("c_time", "c_time", 1600, 600);
-    c_time->Divide(3, 1);
-    c_time->cd(1);
-    hTimeBkgToy->DrawCopy();
-    c_time->cd(2);
-    hTimeSBToy->DrawCopy();
-    c_time->cd(3);
-    hTimePseudoExp->DrawCopy();
+    // TCanvas *c_time = new TCanvas("c_time", "c_time", 1600, 600);
+    // c_time->Divide(3, 1);
+    // c_time->cd(1);
+    // hTimeBkgToy->DrawCopy();
+    // c_time->cd(2);
+    // hTimeSBToy->DrawCopy();
+    // c_time->cd(3);
+    // hTimePseudoExp->DrawCopy();
 
     output_file->Write();
     output_file->Close();
     std::cout << "Done\n\n" << std::endl;
 
-    // Cleanup 
-    delete cSigConstraint;
-    cSigConstraint = nullptr;
-    delete cBkgConstraint;
-    cBkgConstraint = nullptr;
+    // Cleanup
     delete c_cls;
     c_cls = nullptr;
-    delete c_time;
-    c_time = nullptr;
-
 }
 
 
@@ -676,7 +722,7 @@ void analysisRun(DataPoint point, std::ofstream &prob_file) {
     Main analysis function
 */
 int main(int argc, char *argv[]) {
-    
+
     // Make ROOT run in batch mode
     gROOT->SetBatch(1);
 
@@ -686,9 +732,9 @@ int main(int argc, char *argv[]) {
 
     // NB: change this to get different results every time.
     RooRandom::randomGenerator()->SetSeed(42);
-    
+
     try {
-        // Load the config file 
+        // Load the config file
         const char* configFile = app.Argv(1);
         std::map<std::string, std::string> config = load_Config(configFile);
 
@@ -712,9 +758,9 @@ int main(int argc, char *argv[]) {
         if(config["runType"] == "full") {
             // Perform the analysis over the entire file
             std::cout << "Running full analysis over all data points\n\n";
-            for(auto point : data)    
+            for(auto point : data)
                 analysisRun(point, prob_file);
-        } 
+        }
         else if(config["runType"] == "point") {
             if(config["mass"] == "") {
                 // If the mass point is not specified for analysis, exit with an error


### PR DESCRIPTION
Uses ROOT's `TProcessExecutor` to fan-out pseudo-experiment executor to all available cores. Just for safety, I recreate the entire statistical model (all variables and PDFs) inside the `runPseudoExperiment` function, but thankfully it doesn't seem to consume too much memory.

Result:

<img width="1747" height="343" alt="image" src="https://github.com/user-attachments/assets/00c29b20-710d-4266-b4fc-e005be21a970" />

It doesn't crash and it seems to run for a while, so I'm going to guess it should do the right thing. @danielcostache maybe we could run some more tests next week, see if this code works correctly?

Thanks to GitHub Copilot for helping me quickly get to terms with the ROOT API.